### PR TITLE
INS-194: Clinical Trials count in Program Detail was fixed.

### DIFF
--- a/src/main/resources/graphql/ins.graphql
+++ b/src/main/resources/graphql/ins.graphql
@@ -393,8 +393,9 @@ type QueryType {
     programClinicalTrialCount(program_id: String): Int @cypher(statement: """
         MATCH (p:program {program_id: $program_id})
         OPTIONAL MATCH (p)<--(pr:project)
-        OPTIONAL MATCH (pr)<--(c:clinical_trial)
-        RETURN COUNT(DISTINCT c)
+        OPTIONAL MATCH (ct:clinical_trial)
+            WHERE (pr)<--(:publication)<--(ct) OR (pr)<--(ct)
+        RETURN COUNT(DISTINCT ct)
     """, passThrough: true)
 
     programPatentCount(program_id: String): Int @cypher(statement: """


### PR DESCRIPTION
The count for Clinical Trials in the Program Detail page was wrong. The reason for this was that the Neo4j query which supplied that data was out of date, it had not been modified since the beginning of the project.