### PR TITLE
INS-216: About Page in Global Search

### DIFF
--- a/src/main/java/gov/nih/nci/bento/model/BentoEsFilter.java
+++ b/src/main/java/gov/nih/nci/bento/model/BentoEsFilter.java
@@ -660,10 +660,10 @@ public class BentoEsFilter implements DataFetcher {
 
         }
 
-        // List<Map<String, String>> about_results = searchAboutPage(input);
-        // int about_count = about_results.size();
-        // result.put("about_count", about_count);
-        // result.put("about_page", paginate(about_results, size, offset));
+        List<Map<String, String>> about_results = searchAboutPage(input);
+        int about_count = about_results.size();
+        result.put("about_count", about_count);
+        result.put("about_page", paginate(about_results, size, offset));
 
         return result;
     }
@@ -692,6 +692,7 @@ public class BentoEsFilter implements DataFetcher {
                     ),
                 "size", ESService.MAX_ES_SIZE
         );
+        System.out.println(gson.toJson(query).toString());
         Request request = new Request("GET", GS_ABOUT_END_POINT);
         request.setJsonEntity(gson.toJson(query));
         JsonObject jsonObject = esService.send(request);

--- a/src/main/resources/graphql/es-schema-ins.graphql
+++ b/src/main/resources/graphql/es-schema-ins.graphql
@@ -254,6 +254,9 @@ type GS_About {
 type GlobalSearchResult {
     project_count: String
     projects: [GS_Project]
+
+    about_count: Int
+    about_page: [GS_About]
 }
 
 type DEPRECATEDGlobalSearchResult {


### PR DESCRIPTION
Enabled the About Page search in Bento along with returning the About Page results via GraphQL response parameters. There still needs to be frontend integration.