### PR TITLE
INS-235 make program_officers sortable for Project tab

### DIFF
--- a/src/main/java/gov/nih/nci/bento/model/BentoEsFilter.java
+++ b/src/main/java/gov/nih/nci/bento/model/BentoEsFilter.java
@@ -1228,6 +1228,7 @@ public class BentoEsFilter implements DataFetcher {
                 Map.entry("project_id", "project_id.sort"),
                 Map.entry("project_title", "project_title.sort"),
                 Map.entry("principal_investigators", "principal_investigators"),
+                Map.entry("program_officers", "program_officers.sort"),
                 Map.entry("project_end_date", "project_end_date")
         );
 


### PR DESCRIPTION
Added functionality for sorting upon program_officers data for when program_officers data is displayed as a column in the Project tab on the Explore page.