### PR TITLE
Changed project_count to Int type for result page calculation

### DIFF
--- a/src/main/resources/graphql/es-schema-ins.graphql
+++ b/src/main/resources/graphql/es-schema-ins.graphql
@@ -257,7 +257,7 @@ type GS_Title {
 }
 
 type GlobalSearchResult {
-    project_count: String
+    project_count: Int
     project_titles: [GS_Title]
     projects: [GS_Project]
 


### PR DESCRIPTION
Subhash let me know about this issue, just a quick fix. Downstream from this, the 'total results' in the Global Search results page sums all of the *_count for each tab (about_count, project_count, and more in the future). If the project_count is a String (it was a String), then concatenation occurs instead of integer arithmetic.