### PR TITLE
INS-254: Add activity code to programDetail

### DIFF
--- a/src/main/resources/graphql/ins.graphql
+++ b/src/main/resources/graphql/ins.graphql
@@ -126,6 +126,7 @@ type ProgramInfo {
 
 type ProjectInfo {
     project_id: String
+    activity_code: String
     application_id: String
     fiscal_year: String
     project_title: String
@@ -1041,7 +1042,7 @@ type QueryType {
             num_geos: 1,
             num_sras: 1,
             num_clinical_trials: 1,
-            projects: collect(DISTINCT pr {.*})
+            projects: collect(DISTINCT pr {.*, activity_code: SUBSTRING(pr.project_id, 1,3)})
         }
     """, passThrough: true)
 


### PR DESCRIPTION
The Program Detail page's table of project information will need to have a column for activity_code. This activity_code data resides in OpenSearch naturally (after loading from Neo4j), but this activity_code data is not a property of the 'project' nodes in Neo4j natively. The programDetail endpoint is a Neo4j endpoint.

I added this derived feature to the programDetail response in a way similar to how OpenSearch is populated from Neo4j.