### PR TITLE
INS-238: Updated Principal Investigators to sort properly

### DIFF
--- a/src/main/java/gov/nih/nci/bento/model/BentoEsFilter.java
+++ b/src/main/java/gov/nih/nci/bento/model/BentoEsFilter.java
@@ -1227,7 +1227,7 @@ public class BentoEsFilter implements DataFetcher {
                 Map.entry("activity_code", "activity_code.sort"),
                 Map.entry("project_id", "project_id.sort"),
                 Map.entry("project_title", "project_title.sort"),
-                Map.entry("principal_investigators", "principal_investigators"),
+                Map.entry("principal_investigators", "principal_investigators.sort"),
                 Map.entry("program_officers", "program_officers.sort"),
                 Map.entry("project_end_date", "project_end_date")
         );


### PR DESCRIPTION
This was an oversight. There was a sortable property in the 'projects' index that was never tapped into, for sorting against, in the WebService for Principal Investigators. The rest of the properties that are columns in the Projects tab in the Explore page should work properly already.