### PR TITLE
INS-453: DOC OD issue

### DIFF
--- a/src/main/java/gov/nih/nci/bento/service/ESService.java
+++ b/src/main/java/gov/nih/nci/bento/service/ESService.java
@@ -200,7 +200,8 @@ public class ESService {
         // List<Map<String, Object>> fields = new LinkedList<Map<String, Object>>();
         Map<String, Object> fields = new HashMap<String, Object>();
         for (String field: termAggNames) {
-            fields.put(field, Map.of("terms", Map.of("field", field)));
+            // the "size": 50 is so that we can have more than 10 buckets returned for our aggregations (the default)
+            fields.put(field, Map.of("terms", Map.of("field", field, "size", 50)));
         }
         newQuery.put("aggs", fields);
         return newQuery;


### PR DESCRIPTION
The problem has to do with the default behavior of OpenSearch. By default, for any operation/query, OpenSearch returns the top 10 results. These results could be documents or even aggregation buckets (like how many of each DOC there are).

With the addition of the DOC OCC in our data, we now have 11 DOCS.

The fix involved setting the max number of results which can be returned, upon generating the aggregation section of a query in the Bento ESService.java