### PR TITLE
Ins 479: Make most endpoints OpenSearch-backed

### DIFF
--- a/src/main/java/gov/nih/nci/bento/model/BentoEsFilter.java
+++ b/src/main/java/gov/nih/nci/bento/model/BentoEsFilter.java
@@ -157,6 +157,38 @@ public class BentoEsFilter implements DataFetcher {
                             Map<String, Object> args = env.getArguments();
                             return projectOverView(args);
                         })
+                        .dataFetcher("numberOfPrograms", env -> {
+                            Map<String, Object> args = env.getArguments();
+                            return numberOfPrograms(args);
+                        })
+                        .dataFetcher("numberOfProjects", env -> {
+                            Map<String, Object> args = env.getArguments();
+                            return numberOfProjects(args);
+                        })
+                        .dataFetcher("numberOfPublications", env -> {
+                            Map<String, Object> args = env.getArguments();
+                            return numberOfPublications(args);
+                        })
+                        .dataFetcher("numberOfGEOs", env -> {
+                            Map<String, Object> args = env.getArguments();
+                            return numberOfGEOs(args);
+                        })
+                        .dataFetcher("numberOfSRAs", env -> {
+                            Map<String, Object> args = env.getArguments();
+                            return numberOfSRAs(args);
+                        })
+                        .dataFetcher("numberOfDBGaps", env -> {
+                            Map<String, Object> args = env.getArguments();
+                            return numberOfDBGaps(args);
+                        })
+                        .dataFetcher("numberOfClinicalTrials", env -> {
+                            Map<String, Object> args = env.getArguments();
+                            return numberOfClinicalTrials(args);
+                        })
+                        .dataFetcher("numberOfPatents", env -> {
+                            Map<String, Object> args = env.getArguments();
+                            return numberOfPatents(args);
+                        })
                 )
                 .build();
     }
@@ -1249,5 +1281,85 @@ public class BentoEsFilter implements DataFetcher {
         );
 
         return overview(PROJECTS_END_POINT, params, PROPERTIES, defaultSort, mapping);
+    }
+
+    private Integer numberOfPrograms(Map<String, Object> params) throws IOException {
+        Map<String, Object> query = esService.buildFacetFilterQuery(Map.of(), Set.of());
+
+        Request request = new Request("GET", PROGRAMS_COUNT_END_POINT);
+        request.setJsonEntity(gson.toJson(query));
+        JsonObject result = esService.send(request);
+        int number = result.get("count").getAsInt();
+        return number;
+    }
+
+    private Integer numberOfProjects(Map<String, Object> params) throws IOException {
+        Map<String, Object> query = esService.buildFacetFilterQuery(Map.of(), Set.of());
+
+        Request request = new Request("GET", PROJECTS_COUNT_END_POINT);
+        request.setJsonEntity(gson.toJson(query));
+        JsonObject result = esService.send(request);
+        int number = result.get("count").getAsInt();
+        return number;
+    }
+
+    private Integer numberOfPublications(Map<String, Object> params) throws IOException {
+        Map<String, Object> query = esService.buildFacetFilterQuery(Map.of(), Set.of());
+
+        Request request = new Request("GET", PUBLICATIONS_COUNT_END_POINT);
+        request.setJsonEntity(gson.toJson(query));
+        JsonObject result = esService.send(request);
+        int number = result.get("count").getAsInt();
+        return number;
+    }
+
+    private Integer numberOfGEOs(Map<String, Object> params) throws IOException {
+        Map<String, Object> query = esService.buildFacetFilterQuery(Map.of("transformed_type", List.of("GEO")), Set.of());  // RANGE_PARAMS
+
+        Request request = new Request("GET", DATASETS_COUNT_END_POINT);
+        request.setJsonEntity(gson.toJson(query));
+        JsonObject result = esService.send(request);
+        int number = result.get("count").getAsInt();
+        return number;
+    }
+
+    private Integer numberOfSRAs(Map<String, Object> params) throws IOException {
+        Map<String, Object> query = esService.buildFacetFilterQuery(Map.of("transformed_type", List.of("SRA")), Set.of());  // RANGE_PARAMS
+
+        Request request = new Request("GET", DATASETS_COUNT_END_POINT);
+        request.setJsonEntity(gson.toJson(query));
+        JsonObject result = esService.send(request);
+        int number = result.get("count").getAsInt();
+        return number;
+    }
+
+    private Integer numberOfDBGaps(Map<String, Object> params) throws IOException {
+        Map<String, Object> query = esService.buildFacetFilterQuery(Map.of("transformed_type", List.of("dbGaP")), Set.of());  // RANGE_PARAMS
+
+        Request request = new Request("GET", DATASETS_COUNT_END_POINT);
+        request.setJsonEntity(gson.toJson(query));
+        JsonObject result = esService.send(request);
+        int number = result.get("count").getAsInt();
+        return number;
+    }
+
+    private Integer numberOfClinicalTrials(Map<String, Object> params) throws IOException {
+        Map<String, Object> query = esService.buildFacetFilterQuery(Map.of(), Set.of());
+
+        Request request = new Request("GET", CLINICAL_TRIALS_COUNT_END_POINT);
+        request.setJsonEntity(gson.toJson(query));
+        JsonObject result = esService.send(request);
+        int number = result.get("count").getAsInt();
+        return number;
+    }
+
+    private Integer numberOfPatents(Map<String, Object> params) throws IOException {
+        Map<String, Object> query = esService.buildFacetFilterQuery(Map.of(), Set.of());
+
+        Request request = new Request("GET", PATENTS_COUNT_END_POINT);
+        request.setJsonEntity(gson.toJson(query));
+        JsonObject result = esService.send(request);
+        int number = result.get("count").getAsInt();
+        return number;
     }
 }

--- a/src/main/java/gov/nih/nci/bento/model/BentoEsFilter.java
+++ b/src/main/java/gov/nih/nci/bento/model/BentoEsFilter.java
@@ -205,6 +205,15 @@ public class BentoEsFilter implements DataFetcher {
                             Map<String, Object> args = env.getArguments();
                             return programPatentCount(args);
                         })
+                        // TODO: adeforge 12/08/2022 -- this probably needs to be a table
+                        // .dataFetcher("programInfo", env -> {
+                        //     Map<String, Object> args = env.getArguments();
+                        //     return programInfo(args);
+                        // })
+                        .dataFetcher("projectDetail", env -> {
+                            Map<String, Object> args = env.getArguments();
+                            return projectDetail(args);
+                        })
                 )
                 .build();
     }
@@ -1417,5 +1426,103 @@ public class BentoEsFilter implements DataFetcher {
         JsonObject result = esService.send(request);
         int number = result.get("count").getAsInt();
         return number;
+    }
+
+    // private Map<String, Object> programInfo(Map<String, Object> params) throws IOException {
+    //     final String AGG_NAME = "agg_name";
+    //     final String AGG_ENDPOINT = "agg_endpoint";
+    //     // final String WIDGET_QUERY = "widgetQueryName";
+    //     // final String FILTER_COUNT_QUERY = "filterCountQueryName";
+        
+    //     Map<String, Object> query = esService.buildFacetFilterQuery(Map.of(), Set.of());
+
+    //     final List<Map<String, String>> PROGRAM_TERM_AGGS = new ArrayList<>();
+    //     PROGRAM_TERM_AGGS.add(Map.of(
+    //         AGG_NAME, "programs",
+    //         // WIDGET_QUERY, "publicationCountByCitation",
+    //         // FILTER_COUNT_QUERY, "filterPublicationCountByCitation",
+    //         AGG_ENDPOINT, PROGRAMS_END_POINT
+    //     ));
+
+    //     List<String> publication_agg_names = new ArrayList<>();
+    //     for (var agg: PROGRAM_TERM_AGGS) {
+    //         publication_agg_names.add(agg.get(AGG_NAME));
+    //     }
+    //     final String[] PROGRAMS_TERM_AGG_NAMES = publication_agg_names.toArray(new String[PROGRAM_TERM_AGGS.size()]);
+
+    //     Map<String, Object> programAggQuery = esService.addAggregations(query, PROGRAMS_TERM_AGG_NAMES, new String[]{});
+    //     Request programRequest = new Request("GET", PROGRAMS_END_POINT);
+    //     programRequest.setJsonEntity(gson.toJson(programAggQuery));
+    //     JsonObject programResult = esService.send(programRequest);
+    //     Map<String, JsonArray> programAggs = esService.collectTermAggs(programResult, PROGRAMS_TERM_AGG_NAMES);
+        
+    //     System.out.println(programAggs);
+
+    //     return null;
+    // }
+
+    private Map<String, Object> projectDetail(Map<String, Object> params) throws IOException {
+        final String[][] PROPERTIES = new String[][]{
+            new String[]{"program", "programs"},
+            new String[]{"activity_code", "activity_code"},
+            new String[]{"project_id", "project_id"},
+            new String[]{"application_id", "application_id"},
+            new String[]{"fiscal_year", "fiscal_years"},
+            new String[]{"project_title", "project_title"},
+            new String[]{"project_type", "project_type"},
+            new String[]{"abstract_text", "abstract_text"},
+            new String[]{"keywords", "keywords"},
+            new String[]{"org_name", "org_name"},
+            new String[]{"org_city", "org_citie"},
+            new String[]{"org_state", "org_state"},
+            new String[]{"org_country", "org_country"},
+            new String[]{"principal_investigators", "principal_investigators"},
+            new String[]{"lead_doc", "docs"},
+            new String[]{"program_officers", "program_officers"},
+            new String[]{"award_amount", "award_amount"},
+            new String[]{"nci_funded_amount", "nci_funded_amount"},
+            new String[]{"award_notice_date", "award_notice_date"},
+            new String[]{"project_start_date", "project_start_date"},
+            new String[]{"project_end_date", "project_end_date"},
+            new String[]{"full_foa", "full_foa"},
+        };
+
+        // get the data
+        Map<String,Object> query = esService.buildFacetFilterQuery(Map.of("project_id", List.of(params.get("project_id"))), Set.of());  // RANGE_PARAMS
+        Request request = new Request("GET", PROJECTS_END_POINT);
+        Map<String,Object> result = esService.collectPage(request, query, PROPERTIES, 1, 0).get(0);
+
+        // get the counts
+        query = esService.buildFacetFilterQuery(Map.of("project_id", List.of(params.get("project_id"))), Set.of());  // RANGE_PARAMS
+        Request publicationsCountRequest = new Request("GET", PUBLICATIONS_COUNT_END_POINT);
+        publicationsCountRequest.setJsonEntity(gson.toJson(query));
+        JsonObject publicationsCountResult = esService.send(publicationsCountRequest);
+        int numberOfPublications = publicationsCountResult.get("count").getAsInt();
+
+        Request datasetsCountRequest = new Request("GET", DATASETS_COUNT_END_POINT);
+        datasetsCountRequest.setJsonEntity(gson.toJson(query));
+        JsonObject datasetsCountResult = esService.send(datasetsCountRequest);
+        int numberOfDatasets = datasetsCountResult.get("count").getAsInt();
+
+        Request clinicalTrialsCountRequest = new Request("GET", CLINICAL_TRIALS_COUNT_END_POINT);
+        clinicalTrialsCountRequest.setJsonEntity(gson.toJson(query));
+        JsonObject clinicalTrialsCountResult = esService.send(clinicalTrialsCountRequest);
+        int numberOfClinicalTrials = clinicalTrialsCountResult.get("count").getAsInt();
+
+        Request patentsCountRequest = new Request("GET", PATENTS_COUNT_END_POINT);
+        patentsCountRequest.setJsonEntity(gson.toJson(query));
+        JsonObject patentsCountResult = esService.send(patentsCountRequest);
+        int numberOfPatents = patentsCountResult.get("count").getAsInt();
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("num_publications", numberOfPublications);
+        data.put("num_datasets", numberOfDatasets);
+        data.put("num_clinical_trials", numberOfClinicalTrials);
+        data.put("num_patents", numberOfPatents);
+
+        // combine counts and project data
+        result.putAll(data);
+
+        return result;
     }
 }

--- a/src/main/java/gov/nih/nci/bento/model/BentoEsFilter.java
+++ b/src/main/java/gov/nih/nci/bento/model/BentoEsFilter.java
@@ -189,6 +189,22 @@ public class BentoEsFilter implements DataFetcher {
                             Map<String, Object> args = env.getArguments();
                             return numberOfPatents(args);
                         })
+                        .dataFetcher("programPublicationCount", env -> {
+                            Map<String, Object> args = env.getArguments();
+                            return programPublicationCount(args);
+                        })
+                        .dataFetcher("programDatasetCount", env -> {
+                            Map<String, Object> args = env.getArguments();
+                            return programDatasetCount(args);
+                        })
+                        .dataFetcher("programClinicalTrialCount", env -> {
+                            Map<String, Object> args = env.getArguments();
+                            return programClinicalTrialCount(args);
+                        })
+                        .dataFetcher("programPatentCount", env -> {
+                            Map<String, Object> args = env.getArguments();
+                            return programPatentCount(args);
+                        })
                 )
                 .build();
     }
@@ -1355,6 +1371,46 @@ public class BentoEsFilter implements DataFetcher {
 
     private Integer numberOfPatents(Map<String, Object> params) throws IOException {
         Map<String, Object> query = esService.buildFacetFilterQuery(Map.of(), Set.of());
+
+        Request request = new Request("GET", PATENTS_COUNT_END_POINT);
+        request.setJsonEntity(gson.toJson(query));
+        JsonObject result = esService.send(request);
+        int number = result.get("count").getAsInt();
+        return number;
+    }
+
+    private Integer programPublicationCount(Map<String, Object> params) throws IOException {
+        Map<String, Object> query = esService.buildFacetFilterQuery(Map.of("programs", List.of(params.get("program_id"))), Set.of());
+
+        Request request = new Request("GET", PUBLICATIONS_COUNT_END_POINT);
+        request.setJsonEntity(gson.toJson(query));
+        JsonObject result = esService.send(request);
+        int number = result.get("count").getAsInt();
+        return number;
+    }
+
+    private Integer programDatasetCount(Map<String, Object> params) throws IOException {
+        Map<String, Object> query = esService.buildFacetFilterQuery(Map.of("programs", List.of(params.get("program_id"))), Set.of());
+
+        Request request = new Request("GET", DATASETS_COUNT_END_POINT);
+        request.setJsonEntity(gson.toJson(query));
+        JsonObject result = esService.send(request);
+        int number = result.get("count").getAsInt();
+        return number;
+    }
+
+    private Integer programClinicalTrialCount(Map<String, Object> params) throws IOException {
+        Map<String, Object> query = esService.buildFacetFilterQuery(Map.of("programs", List.of(params.get("program_id"))), Set.of());
+
+        Request request = new Request("GET", CLINICAL_TRIALS_COUNT_END_POINT);
+        request.setJsonEntity(gson.toJson(query));
+        JsonObject result = esService.send(request);
+        int number = result.get("count").getAsInt();
+        return number;
+    }
+
+    private Integer programPatentCount(Map<String, Object> params) throws IOException {
+        Map<String, Object> query = esService.buildFacetFilterQuery(Map.of("programs", List.of(params.get("program_id"))), Set.of());
 
         Request request = new Request("GET", PATENTS_COUNT_END_POINT);
         request.setJsonEntity(gson.toJson(query));

--- a/src/main/resources/graphql/es-schema-ins.graphql
+++ b/src/main/resources/graphql/es-schema-ins.graphql
@@ -433,4 +433,13 @@ type QueryType {
     datasetOverView (programs: [String] = [""], docs: [String] = [""], fiscal_years: [String] = [""], award_amounts: [String] = [""], first: Int = 10, offset: Int = 0, order_by: String = "", sort_direction: String = ""): [DatasetOverViewResult]
     datasetOverViewByProject (project_id: [String] = [""], first: Int = 10, offset: Int = 0, order_by: String = "", sort_direction: String = ""): [DatasetOverViewResult]
 
+    numberOfPrograms: Int
+    numberOfProjects: Int
+    numberOfPublications: Int
+    numberOfGEOs: Int
+    numberOfSRAs: Int
+    numberOfDBGaps: Int
+    numberOfClinicalTrials: Int
+    numberOfPatents: Int
+
 }

--- a/src/main/resources/graphql/es-schema-ins.graphql
+++ b/src/main/resources/graphql/es-schema-ins.graphql
@@ -442,4 +442,8 @@ type QueryType {
     numberOfClinicalTrials: Int
     numberOfPatents: Int
 
+    programPublicationCount (program_id: String): Int
+    programDatasetCount (program_id: String): Int
+    programClinicalTrialCount (program_id: String): Int
+    programPatentCount (program_id: String): Int
 }

--- a/src/main/resources/graphql/es-schema-ins.graphql
+++ b/src/main/resources/graphql/es-schema-ins.graphql
@@ -320,6 +320,33 @@ type SearchProjectsResult {
     publicationCountByYear: [SearchProjectsReturnObject]
 }
 
+type ProjectDetailResult {
+    project_id: String
+    application_id: String
+    fiscal_year: String
+    project_title: String
+    project_type: String
+    abstract_text: String
+    keywords: String
+    org_name: String
+    org_city: String
+    org_state: String
+    org_country: String
+    principal_investigators: String
+    lead_doc: String
+    program_officers: String
+    award_amount: String
+    nci_funded_amount: String
+    award_notice_date: String
+    project_start_date: String
+    project_end_date: String
+    full_foa: String
+    num_publications: Int
+    num_datasets: Int
+    num_clinical_trials: Int
+    num_patents: Int
+}
+
 schema {
     query: QueryType
 }
@@ -446,4 +473,6 @@ type QueryType {
     programDatasetCount (program_id: String): Int
     programClinicalTrialCount (program_id: String): Int
     programPatentCount (program_id: String): Int
+
+    projectDetail (project_id: String): ProjectDetailResult
 }

--- a/src/main/resources/graphql/ins.graphql
+++ b/src/main/resources/graphql/ins.graphql
@@ -354,7 +354,7 @@ type QueryType {
         }
     """, passThrough: true)
 
-    programPublicationCount(program_id: String): Int @cypher(statement: """
+    DEPRECATEDprogramPublicationCount(program_id: String): Int @cypher(statement: """
         MATCH (p:program {program_id: $program_id})
         OPTIONAL MATCH (p)<--(pr:project)
         OPTIONAL MATCH (pr)<--(pub:publication)
@@ -382,14 +382,14 @@ type QueryType {
         RETURN count(DISTINCT d)
     """, passThrough: true)
 
-    programDatasetCount(program_id: String): Int @cypher(statement: """
+    DEPRECATEDprogramDatasetCount(program_id: String): Int @cypher(statement: """
         MATCH (p:program {program_id: $program_id})
         OPTIONAL MATCH (p)<--(:project)<--(:publication)<--(ds)
         WHERE ds:geo OR ds:sra OR ds:dbgap
         RETURN COUNT(DISTINCT ds)
     """, passThrough: true)
 
-    programClinicalTrialCount(program_id: String): Int @cypher(statement: """
+    DEPRECATEDprogramClinicalTrialCount(program_id: String): Int @cypher(statement: """
         MATCH (p:program {program_id: $program_id})
         OPTIONAL MATCH (p)<--(pr:project)
         OPTIONAL MATCH (ct:clinical_trial)
@@ -397,7 +397,7 @@ type QueryType {
         RETURN COUNT(DISTINCT ct)
     """, passThrough: true)
 
-    programPatentCount(program_id: String): Int @cypher(statement: """
+    DEPRECATEDprogramPatentCount(program_id: String): Int @cypher(statement: """
         MATCH (p:program {program_id: $program_id})
         OPTIONAL MATCH (p)<--(:project)<--(pat)
         WHERE pat:granted_patent OR pat:patent_application

--- a/src/main/resources/graphql/ins.graphql
+++ b/src/main/resources/graphql/ins.graphql
@@ -208,7 +208,7 @@ type ProgramDetail {
     projects: [ProjectInfo]
 }
 
-type ProjectDetail {
+type DEPRECATEDProjectDetail {
     project_id: String
     application_id: String
     fiscal_year: String
@@ -341,7 +341,7 @@ type QueryType {
     DEPRECATEDnumberOfDBGaps: Int @cypher(statement: "MATCH (n:dbgap) return count(n)")
     DEPRECATEDnumberOfClinicalTrials: Int @cypher(statement: "MATCH (n:clinical_trial) return count(n)")
 
-    programInfo: [ProgramInfo] @cypher(statement: """
+    programInfo: [DEPRECATEDProgramInfo] @cypher(statement: """
         MATCH (p:program)
         OPTIONAL MATCH (p)<--(pr:project)
         OPTIONAL MATCH (pr)<--(pub:publication)
@@ -1044,7 +1044,7 @@ type QueryType {
         }
     """, passThrough: true)
 
-    projectDetail(project_id: String): ProjectDetail @cypher(statement:  """
+    DEPRECATEDprojectDetail(project_id: String): DEPRECATEDProjectDetail @cypher(statement:  """
         MATCH (pr:project {project_id: $project_id})
         OPTIONAL MATCH (pr)<--(pub:publication)
         OPTIONAL MATCH (pub)<--(dt)

--- a/src/main/resources/graphql/ins.graphql
+++ b/src/main/resources/graphql/ins.graphql
@@ -341,7 +341,7 @@ type QueryType {
     DEPRECATEDnumberOfDBGaps: Int @cypher(statement: "MATCH (n:dbgap) return count(n)")
     DEPRECATEDnumberOfClinicalTrials: Int @cypher(statement: "MATCH (n:clinical_trial) return count(n)")
 
-    programInfo: [DEPRECATEDProgramInfo] @cypher(statement: """
+    programInfo: [ProgramInfo] @cypher(statement: """
         MATCH (p:program)
         OPTIONAL MATCH (p)<--(pr:project)
         OPTIONAL MATCH (pr)<--(pub:publication)

--- a/src/main/resources/graphql/ins.graphql
+++ b/src/main/resources/graphql/ins.graphql
@@ -333,13 +333,13 @@ type QueryType {
     schemaVersion: String @cypher(statement: "RETURN '1.1.0'")
 
     "Simple counts"
-    numberOfPrograms: Int @cypher(statement: "MATCH (n:program) return count(n)")
-    numberOfProjects: Int @cypher(statement: "MATCH (n:project) return count(n)")
-    numberOfPublications: Int @cypher(statement: "MATCH (n:publication) return count(n)")
-    numberOfGEOs: Int @cypher(statement: "MATCH (n:geo) return count(n)")
-    numberOfSRAs: Int @cypher(statement: "MATCH (n:sra) return count(n)")
-    numberOfDBGaps: Int @cypher(statement: "MATCH (n:dbgap) return count(n)")
-    numberOfClinicalTrials: Int @cypher(statement: "MATCH (n:clinical_trial) return count(n)")
+    DEPRECATEDnumberOfPrograms: Int @cypher(statement: "MATCH (n:program) return count(n)")
+    DEPRECATEDnumberOfProjects: Int @cypher(statement: "MATCH (n:project) return count(n)")
+    DEPRECATEDnumberOfPublications: Int @cypher(statement: "MATCH (n:publication) return count(n)")
+    DEPRECATEDnumberOfGEOs: Int @cypher(statement: "MATCH (n:geo) return count(n)")
+    DEPRECATEDnumberOfSRAs: Int @cypher(statement: "MATCH (n:sra) return count(n)")
+    DEPRECATEDnumberOfDBGaps: Int @cypher(statement: "MATCH (n:dbgap) return count(n)")
+    DEPRECATEDnumberOfClinicalTrials: Int @cypher(statement: "MATCH (n:clinical_trial) return count(n)")
 
     programInfo: [ProgramInfo] @cypher(statement: """
         MATCH (p:program)
@@ -520,7 +520,7 @@ type QueryType {
         RETURN COUNT(DISTINCT dt.accession)
     """, passThrough: true)
 
-    numberOfPatents(project_ids: [String] = []): Int @cypher(statement: """
+    DEPRECATEDnumberOfPatents(project_ids: [String] = []): Int @cypher(statement: """
         MATCH (pr:project)
             WHERE (size($project_ids) = 0 OR pr.project_id IN $project_ids)
         OPTIONAL MATCH (pr)<--(p)


### PR DESCRIPTION
We are covering the Home Page's numberOf* endpoints (status chart graphic), Project Detail page's projectDetail endpoint (status bar and project info because they are a part of the same endpoint and we don't want to break the API), and Program Detail page's program*Count (status bar).

There are still Neo4j-backed endpoints, but this is what was asked for explicitly.

* designated Publication/ClinicalTrial/Patent, etc.