### PR TITLE
INS-513: Fourth pass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,8 +191,16 @@
 		<dependency>
 			<groupId>org.neo4j.driver</groupId>
 			<artifactId>neo4j-java-driver</artifactId>
-			<version>4.4.9</version>
+			<version>4.4.11</version>
 		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib -->
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib</artifactId>
+			<version>1.6.0</version>
+		</dependency>
+
 
 		<!-- <dependency>
 			<groupId>org.neo4j</groupId>


### PR DESCRIPTION
Fourth pass at the vulnerability remediation. Spot including a kotlin lib and bumping the version for a neo4j-java-driver.