### PR TITLE
CVE-2024-56337

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ COPY . .
 RUN mvn package -DskipTests
 
 # Production stage
-
-
 FROM tomcat:11.0.4-jdk17 AS fnl_base_image
+
+RUN apt-get update && apt-get -y upgrade
 
 # install dependencies and clean up unused files
 RUN apt-get update && apt-get install unzip

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN mvn package -DskipTests
 # Production stage
 
 
-FROM tomcat:10.1.30-jdk17 AS fnl_base_image
+FROM tomcat:11.0.4-jdk17 AS fnl_base_image
 
 # install dependencies and clean up unused files
 RUN apt-get update && apt-get install unzip

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-log4j2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>10.1.28</version>
+            <version>10.1.34</version>
         </dependency>
         <!-- JUnit -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-log4j2</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Updated Tomcat versions to fix vulnerability CVE-2024-56337.
The vulnerability lists the following affected versions:
- 11.0.0-M1 through 11.0.1
- 10.1.0-M1 through 10.1.33
- 9.0.0.M1 through 9.0.97

The POM XML listed a 10.x version, so I used 10.1.34, just outside the affected range.
I used 11.0.4 in the Dockerfile, because that's what C3DC (https://github.com/CBIIT/CCDI-C3DC-Backend/pull/63/files) and CCDI Hub (https://github.com/CBIIT/CCDI-Portal-WebService/pull/95/files) use.
I added the line `RUN apt-get update && apt-get -y upgrade` to the Dockerfile, because C3DC and CCDI Hub have it.