### PR TITLE
CVE-2025-24813 Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
         <version>3.4.3</version>
     </parent>
 
-
     <properties>
         <java.version>17</java.version>
         <spring.version>6.2.3</spring.version>
@@ -72,7 +71,6 @@
             <artifactId>spring-webmvc</artifactId>
             <version>${spring.version}</version>
         </dependency>
-  
         <dependency>
             <groupId>org.springframework.restdocs</groupId>
             <artifactId>spring-restdocs-core</artifactId>
@@ -104,8 +102,8 @@
             <version>2.0</version>
         </dependency>
         <dependency>  
-			<groupId>com.github.ben-manes.caffeine</groupId>  
-			<artifactId>caffeine</artifactId>
+            <groupId>com.github.ben-manes.caffeine</groupId>  
+            <artifactId>caffeine</artifactId>
             <version>3.1.8</version>
             <exclusions>
                 <exclusion>
@@ -190,64 +188,62 @@
             <groupId>org.opensearch.client</groupId>
             <artifactId>opensearch-rest-client</artifactId>
             <version>2.5.0</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpclient</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpcore</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpcore-nio</artifactId>
-				</exclusion>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore-nio</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
-			</exclusions>
+            </exclusions>
         </dependency>
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>4.5.13</version>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
-			</exclusions>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpcore-nio</artifactId>
-			<version>4.4.16</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpcore</artifactId>
-			<version>4.4.16</version>
-		</dependency>
-		<dependency>
-			<groupId>org.opensearch.client</groupId>
-			<artifactId>opensearch-rest-high-level-client</artifactId>
-			<version>2.5.0</version>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore-nio</artifactId>
+            <version>4.4.16</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.16</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opensearch.client</groupId>
+            <artifactId>opensearch-rest-high-level-client</artifactId>
+            <version>2.5.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>joda-time</groupId>
                     <artifactId>joda-time</artifactId>
                 </exclusion>
             </exclusions>
-		</dependency>
+        </dependency>
         <!-- AWS Java SDK -->
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
-             <version>1.12.772</version>
+            <version>1.12.772</version>
             <scope>compile</scope>
         </dependency>
         <!-- Lombok -->
@@ -283,17 +279,17 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.0.0-M2</version>
                 <executions>
-                  <execution>
-                    <id>enforce</id>
-                    <configuration>
-                      <rules>
-                        <dependencyConvergence/>
-                      </rules>
-                    </configuration>
-                    <goals>
-                      <goal>enforce</goal>
-                    </goals>
-                  </execution>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <dependencyConvergence/>
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -17,14 +17,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.0.13</version>
+        <version>3.4.3</version>
     </parent>
 
 
     <properties>
         <java.version>17</java.version>
-        <spring.version>6.0.14</spring.version>
-        <spring.restdocs.version>3.0.1</spring.restdocs.version>
+        <spring.version>6.2.3</spring.version>
+        <spring.restdocs.version>3.0.3</spring.restdocs.version>
         <snakeyaml.version>2.0</snakeyaml.version>
     </properties>
 
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.9.1</version>
+            <version>2.11.0</version>
             <scope>compile</scope>
         </dependency>
             <!-- YAML -->
@@ -107,6 +107,12 @@
 			<groupId>com.github.ben-manes.caffeine</groupId>  
 			<artifactId>caffeine</artifactId>
             <version>3.1.8</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Unirest Java -->
         <dependency>
@@ -124,7 +130,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>10.1.34</version>
+            <version>10.1.36</version>
         </dependency>
         <!-- JUnit -->
         <dependency>
@@ -156,7 +162,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-graphql-java</artifactId>
-            <version>1.8.0</version>
+            <version>1.9.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.graphql-java</groupId>
@@ -167,12 +173,12 @@
         <dependency>
             <groupId>org.neo4j.driver</groupId>
             <artifactId>neo4j-java-driver</artifactId>
-            <version>4.4.9</version>
+            <version>5.27.0</version>
         </dependency>
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-cypher-dsl</artifactId>
-            <version>2023.0.0</version>
+            <version>2023.9.5</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
@@ -206,7 +212,13 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.14</version>
+			<version>4.5.13</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Fixes vulnerability CVE-2025-24813 by upgrading Tomcat from `10.1.34` to `10.1.36`.
Upgrading Tomcat required some other dependencies to upgrade as well.
After upgrading Tomcat, the application would fail to start. Therefore, I upgraded the some other dependencies, such as Neo4j dependencies, to the same versions used in [this CCDI Hub pull request](https://github.com/CBIIT/CCDI-Portal-WebService/pull/95). The application then succeeded to start.