### PR TITLE
INS-1604 CVE Fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN mvn package -DskipTests
 
 # Production stage
-FROM tomcat:11.0.20-jdk17 AS fnl_base_image
+FROM tomcat:11.0.21-jdk17 AS fnl_base_image
 
 RUN apt-get update && apt-get -y upgrade
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-            <version>4.1.125.Final</version>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+                <version>4.1.125.Final</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -196,7 +196,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>11.0.20</version>
+            <version>11.0.21</version>
         </dependency>
         <!-- JUnit -->
         <dependency>


### PR DESCRIPTION
### Overview

This PR bumps Apache Tomcat to 11.0.21 to fix multiple high CVEs.

### Change Details (Specifics)

N/A

### Related Ticket(s)

INS-1604
INS-1614
